### PR TITLE
Add Docker setup for live -development and production builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# a good .dockerignore is super important,
+# otherwise Docker ends up copying lots of junk into your build context and slowing everything down.
+# --------------------------------------------
+
+# Node modules
+node_modules
+npm-debug.log
+yarn-debug.log
+yarn-error.log
+pnpm-debug.log
+
+# Build output
+dist
+build
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# IDE/project files
+.vscode
+.idea
+*.iml
+
+# Git
+.git
+.gitignore
+
+# Docker files
+Dockerfile*
+docker-compose*.yml

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,14 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+# Expose the dev server port
+EXPOSE 8080
+
+#CMD ["npm", "run", "dev"]
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,26 @@
+# Build stage
+FROM node:18-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# Production stage with nginx
+FROM nginx:alpine
+
+# Remove default nginx static assets
+RUN rm -rf /usr/share/nginx/html/*
+
+# Copy built game into nginx’s web root
+COPY --from=build /app/dist /usr/share/nginx/html
+
+# Expose port
+EXPOSE 80
+
+# Start nginx
+CMD ["nginx", "-g", "daemon off;"]
+

--- a/README-docker.md
+++ b/README-docker.md
@@ -1,0 +1,92 @@
+# Why you may not see your Vite app in Docker
+
+When you run: `npm run dev` Vite starts a development web server inside the container.
+
+By default, it binds to:
+- **Host** (bind address): `127.0.0.1` (aka `localhost`)
+- **Port**: 5173 (default, unless you override it in `vite.config.ts`)
+
+So inside the container, it's listening on `127.0.0.1:5173`.
+
+What this means is that, it "only accept connections that originate from inside the container itself."
+
+So, even if you expose or map ports in Docker, nothing outside the container can connect, because the server isn't listening on the container's external interface `0.0.0.0`.
+
+```yaml
+Container
+ ├── 127.0.0.1:5173 (only inside the container)
+ └── 0.0.0.0:5173 (reachable from outside, if bound)
+
+```
+
+```yaml
+Host (your machine)         Container
++-------------------+       +---------------------+
+| curl localhost:3000| ---> |  127.0.0.1:5173     |  ❌ only listens inside
+|                   |       |                     |
++-------------------+       +---------------------+
+```
+
+Hence, we may see this message when running `docker compose up` 
+```sh
+➜  Local:   http://localhost:5173/
+➜  Network: use --host to expose
+```
+
+This means that inside the container its listening on 5173, but only on localhost (127.0.0.1), not on 0.0.0.0. We need to **tell Vite to listen on all interfaces (0.0.0.0)** so Docker can expose it.
+
+There is 2 approaches to solve this:
+
+Option 1: update `vite.config.ts`
+
+```sh
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  optimizeDeps: {
+    exclude: ['lucide-react'],
+  },
+  server: {
+    host: '0.0.0.0',  // 👈 allow external access
+    port: 5173        // 👈 explici is better than implicit
+  }
+});
+
+```
+
+
+Option 2: pass CLI flag in `Dockerfile.dev`
+
+```sh
+# use this:
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
+```
+This way the container runs Vite on `0.0.0.0:5173` (accessible from outside)
+
+```yaml
+Host (your machine)         Container
++-------------------+       +---------------------+
+| curl localhost:3000| ---> |  0.0.0.0:5173       | ✅ open to all interfaces
+|                   |       |                     |
++-------------------+       +---------------------+
+
+```
+
+
+Now you can start developing the app. The following commands may come in handy:
+```sh
+docker compose build mario-dev
+docker compose up mario-dev
+
+# or simply:
+docker compose up --build mario-dev
+
+# run in detached mode:
+docker compose up -d mario-dev
+
+# you can check the logs with:
+docker compose logs -f mario-dev
+
+```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,21 @@
+services:
+  mario-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: mario-dev
+    ports:
+      - "3000:5173"
+    volumes:
+      - .:/app
+      - /app/node_modules
+    restart: unless-stopped
+
+  mario-prod:
+    build:
+      context: .
+      dockerfile: Dockerfile.prod
+    container_name: mario-prod
+    ports:
+      - "8080:80"
+    restart: unless-stopped


### PR DESCRIPTION
This PR adds Docker support to streamline both local development and production builds. Key additions include:

.dockerignore:
Prevents unnecessary files (e.g., node_modules, .env, build outputs, IDE settings) from being copied into the Docker build context, improving performance and reducing image size.

Dockerfile.dev:
Development Dockerfile using node:18-alpine, runs the Vite dev server and exposes it on 0.0.0.0 for accessibility outside the container.

Dockerfile.prod:
Multi-stage production build with node:18-alpine and nginx:alpine, serves the built app via Nginx.

docker-compose.yaml:
Defines two services (mario-dev and mario-prod) for easy orchestration of dev and prod environments.

README-docker.md:
Detailed guide explaining how to use the Docker setup, including why --host 0.0.0.0 is necessary for Vite inside containers.